### PR TITLE
Remove validation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,4 +12,3 @@
     owner: root
     group: root
     mode: '0444'
-    validate: '/sbin/postconf'


### PR DESCRIPTION
- `validate must contain %s: /sbin/postconf`

Might be able to work around with '{{ "%s" | dirname }}', but I am uncertain that the temporary name is a private directory with the correct name